### PR TITLE
fixed windows write pipe + copied catta pipe implementation…

### DIFF
--- a/include/meshlink/compat.h
+++ b/include/meshlink/compat.h
@@ -24,16 +24,6 @@
   #define MESHLINK_API
 #endif
 
-#ifndef PRINT_SIZE_T
-  #ifdef _WIN32
-    #define PRINT_SIZE_T "%Iu"
-    #define PRINT_SSIZE_T "%Id"
-  #else
-    #define PRINT_SIZE_T "%zu"
-    #define PRINT_SSIZE_T "%zd"
-  #endif
-#endif
-
 #ifdef _MSC_VER
   // VS2012 and up has no ssize_t defined, before it was defined as unsigned int
   #ifndef _SSIZE_T_DEFINED

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -68,6 +68,7 @@ libmeshlink_la_SOURCES = \
 	meshlink.c \
 	buffer.c buffer.h \
 	cipher.h \
+	compat/compat.h \
 	conf.c conf.h \
 	connection.c connection.h \
 	crypto.c crypto.h \
@@ -114,6 +115,7 @@ if MINGW
 # require Windows Vista or above (for winsock2)
 AM_CFLAGS += -DWINVER=0x0600 -D_WIN32_WINNT=0x0600
 libmeshlink_la_LDFLAGS += -no-undefined -Wl,--kill-at,--output-def=.libs/libmeshlink-0.def
+libmeshlink_la_SOURCES += compat/wincompat.c compat/wincompat.h
 endif
 
 libmeshlink_la_CFLAGS = $(AM_CFLAGS) -fPIC -I../catta/include/

--- a/src/compat/compat.h
+++ b/src/compat/compat.h
@@ -1,0 +1,23 @@
+#ifndef meshlink_internal_compat_h
+#define meshlink_internal_compat_h
+
+#ifdef _WIN32
+  #include "wincompat.h"
+#else
+  #define meshlink_pipe pipe
+  #define meshlink_closepipe close
+  #define meshlink_writepipe write
+  #define meshlink_readpipe read
+#endif
+
+#ifndef PRINT_SIZE_T
+  #ifdef _WIN32
+    #define PRINT_SIZE_T "%Iu"
+    #define PRINT_SSIZE_T "%Id"
+  #else
+    #define PRINT_SIZE_T "%zu"
+    #define PRINT_SSIZE_T "%zd"
+  #endif
+#endif
+
+#endif // meshlink_internal_compat_h

--- a/src/compat/wincompat.c
+++ b/src/compat/wincompat.c
@@ -1,0 +1,52 @@
+#include "wincompat.h"
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <mswsock.h>
+#include <assert.h>
+
+// copied from catta pipe implementation
+int meshlink_pipe(int pipefd[2])
+{
+    int lsock = (int)INVALID_SOCKET;
+    struct sockaddr_in laddr;
+    socklen_t laddrlen = sizeof(laddr);
+
+    pipefd[0] = pipefd[1] = (int)INVALID_SOCKET;
+
+    // bind a listening socket to a TCP port on localhost
+    laddr.sin_family = AF_INET;
+    laddr.sin_port = 0;
+    laddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if((lsock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) == SOCKET_ERROR)
+        goto fail;
+    if(bind(lsock, (struct sockaddr *)&laddr, sizeof(laddr)) == SOCKET_ERROR)
+        goto fail;
+    if(listen(lsock, 1) == SOCKET_ERROR)
+        goto fail;
+
+    // determine which address (i.e. port) we got bound to
+    if(getsockname(lsock, (struct sockaddr *)&laddr, &laddrlen) == SOCKET_ERROR)
+        goto fail;
+    assert(laddrlen == sizeof(laddr));
+    laddr.sin_family = AF_INET;
+    laddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    // connect and accept
+    if((pipefd[0] = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) == SOCKET_ERROR)
+        goto fail;
+    if(connect(pipefd[0], (const struct sockaddr *)&laddr, sizeof(laddr)) == SOCKET_ERROR)
+        goto fail;
+    if((pipefd[1] = accept(lsock, NULL, NULL)) == SOCKET_ERROR)
+        goto fail;
+
+    // close the listener
+    closesocket(lsock);
+
+    return 0;
+
+fail:
+    closesocket(pipefd[0]);
+    closesocket(lsock);
+    return -1;
+}

--- a/src/compat/wincompat.h
+++ b/src/compat/wincompat.h
@@ -1,0 +1,13 @@
+#ifndef meshlink_internal_wincompat_h
+#define meshlink_internal_wincompat_h
+
+// Windows lacks pipe. It has an equivalent CreatePipe but we really need
+// something to give to WSAPoll, so we fake it with a local TCP socket. (ugh)
+int meshlink_pipe(int pipefd[2]);
+
+// pipe(socket)-specific read/write/close equivalents
+#define meshlink_closepipe closesocket
+#define meshlink_writepipe(s,buf,len) send(s, buf, len, 0)
+#define meshlink_readpipe(s,buf,len) recv(s, buf, len, 0)
+
+#endif // meshlink_internal_wincompat_h


### PR DESCRIPTION
and cleaned PRINT_SIZE from public include headers

I'm scared the compiler gave no error on missing the pipe declaration but with no include it statically linked to the catta internal implementation of pipe
there might be more such implementation internal cross dependencies

while that worked, the write needed to be fixed as windows doesn't support write on sockets
