### PR TITLE
Added meshlink_free to API.

### DIFF
--- a/examples/chatpp.cc
+++ b/examples/chatpp.cc
@@ -40,7 +40,7 @@ static void parse_command(meshlink::mesh *mesh, char *buf) {
 		*arg++ = 0;
 
 	if(!strcasecmp(buf, "invite")) {
-		char *invitation;
+		std::string invitation;
 
 		if(!arg) {
 			fprintf(stderr, "/invite requires an argument!\n");
@@ -48,13 +48,12 @@ static void parse_command(meshlink::mesh *mesh, char *buf) {
 		}
 
 		invitation = mesh->invite(arg);
-		if(!invitation) {
+		if(invitation.empty()) {
 			fprintf(stderr, "Could not invite '%s': %s\n", arg, meshlink::strerror());
 			return;
 		}
 
-		printf("Invitation for %s: %s\n", arg, invitation);
-		free(invitation);
+		printf("Invitation for %s: %s\n", arg, invitation.c_str());
 	} else if(!strcasecmp(buf, "join")) {
 		if(!arg) {
 			fprintf(stderr, "/join requires an argument!\n");

--- a/include/meshlink/meshlink++.h
+++ b/include/meshlink/meshlink++.h
@@ -337,7 +337,7 @@ namespace meshlink {
 		 *  @param name         The name that the invitee will use in the mesh.
 		 *
 		 *  @return             This function returns a string that contains the invitation URL.
-		 *                      The application should call free() after it has finished using the URL.
+		 *                      The application should call meshlink_free() after it has finished using the URL.
 		 */
 		char *invite(const char *name) {
 			return meshlink_invite(handle, name);
@@ -362,7 +362,7 @@ namespace meshlink {
 		 *  granting the local node access to the other node's mesh.
 		 *
 		 *  @return             This function returns a string that contains the exported key and addresses.
-		 *                      The application should call free() after it has finished using this string.
+		 *                      The application should call meshlink_free() after it has finished using this string.
 		 */
 		char *export_key() {
 			return meshlink_export(handle);
@@ -538,6 +538,10 @@ namespace meshlink {
 
 	static inline const char *strerror(errno_t err = meshlink_errno) {
 		return meshlink_strerror(err);
+	}
+
+	static inline void free(void *ptr) {
+		meshlink_free(ptr);
 	}
 
 }

--- a/include/meshlink/meshlink++.h
+++ b/include/meshlink/meshlink++.h
@@ -22,6 +22,7 @@
 
 #include <meshlink/meshlink.h>
 #include <new> // for 'placement new'
+#include <string>
 
 namespace meshlink {
 	class mesh;
@@ -337,10 +338,12 @@ namespace meshlink {
 		 *  @param name         The name that the invitee will use in the mesh.
 		 *
 		 *  @return             This function returns a string that contains the invitation URL.
-		 *                      The application should call meshlink_free() after it has finished using the URL.
 		 */
-		char *invite(const char *name) {
-			return meshlink_invite(handle, name);
+		std::string invite(const char *name) {
+			char* inv = meshlink_invite(handle, name);
+			std::string inv_str = std::string( inv );
+			meshlink_free( inv );
+			return inv_str;
 		}
 
 		/// Use an invitation to join a mesh.
@@ -362,10 +365,12 @@ namespace meshlink {
 		 *  granting the local node access to the other node's mesh.
 		 *
 		 *  @return             This function returns a string that contains the exported key and addresses.
-		 *                      The application should call meshlink_free() after it has finished using this string.
 		 */
-		char *export_key() {
-			return meshlink_export(handle);
+		std::string export_key() {
+			char* key = meshlink_export(handle);
+			std::string key_str = std::string( key );
+			meshlink_free( key );
+			return key_str;
 		}
 
 		/// Import another node's key and addresses.
@@ -539,11 +544,6 @@ namespace meshlink {
 	static inline const char *strerror(errno_t err = meshlink_errno) {
 		return meshlink_strerror(err);
 	}
-
-	static inline void free(void *ptr) {
-		meshlink_free(ptr);
-	}
-
 }
 
 #endif // MESHLINKPP_H

--- a/include/meshlink/meshlink.h
+++ b/include/meshlink/meshlink.h
@@ -132,6 +132,15 @@ struct meshlink_edge {
  */
 extern const char *meshlink_strerror(meshlink_errno_t err);
 
+/// Free memory allocated by Meshlink
+/** This function deallocates memory that has been allocated by meshkink.
+ *  Other Meshlink functions may return pointers to memory that the caller must
+ *  free after use. The caller should use this function to do so.
+ *
+ *  @param ptr  Pointer to the memory to be free'd. Must be allocated by Meshlink.
+ */
+extern void meshlink_free(void *ptr);
+
 /// Open or create a MeshLink instance.
 /** This function opens or creates a MeshLink instance.
  *  The state is stored in the configuration directory passed in the variable @a confbase @a.

--- a/src/meshlink.c
+++ b/src/meshlink.c
@@ -654,6 +654,10 @@ const char *meshlink_strerror(meshlink_errno_t err) {
 	return errstr[err];
 }
 
+void meshlink_free(void *ptr) {
+	free(ptr);
+}
+
 static bool ecdsa_keygen(meshlink_handle_t *mesh) {
 	ecdsa_t *key;
 	FILE *f;


### PR DESCRIPTION
Using meshlink_free on memory allocated by meshlink (rather than calling
free directly) resolves memory management problems on windows; the dll
that allocated the memory must also free it, otherwise heap check
assertions fail.
