### PR TITLE
windows: fix config by binary read/write

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -277,7 +277,7 @@ bool read_config_file(splay_tree_t *config_tree, const char *fname) {
 	config_t *cfg;
 	bool result = false;
 
-	fp = fopen(fname, "r");
+	fp = fopen(fname, "rb");
 
 	if(!fp) {
 		logger(NULL, MESHLINK_ERROR, "Cannot open config file %s: %s", fname, strerror(errno));
@@ -324,7 +324,7 @@ bool write_config_file(const struct splay_tree_t *config_tree, const char *fname
 {
 	FILE *fp;
 
-	fp = fopen(fname, "w+");
+	fp = fopen(fname, "wb+");
 
 	if(!fp) {
 		logger(NULL, MESHLINK_ERROR, "Cannot open config file %s: %s", fname, strerror(errno));
@@ -395,7 +395,7 @@ bool append_config_file(meshlink_handle_t *mesh, const char *name, const char *k
 	char filename[PATH_MAX];
 	snprintf(filename,PATH_MAX, "%s" SLASH "hosts" SLASH "%s", mesh->confbase, name);
 
-	FILE *fp = fopen(filename, "a");
+	FILE *fp = fopen(filename, "ab");
 
 	if(!fp) {
 		logger(mesh, MESHLINK_ERROR, "Cannot open config file %s: %s", filename, strerror(errno));

--- a/src/protocol_auth.c
+++ b/src/protocol_auth.c
@@ -128,7 +128,7 @@ static bool send_proxyrequest(meshlink_handle_t *mesh, connection_t *c) {
 }
 
 bool send_id(meshlink_handle_t *mesh, connection_t *c) {
-	
+
 	int minor = mesh->self->connection->protocol_minor;
 
 	if(mesh->proxytype && c->outgoing)
@@ -152,7 +152,7 @@ static bool finalize_invitation(meshlink_handle_t *mesh, connection_t *c, const 
 		return false;
 	}
 
-	FILE *f = fopen(filename, "w");
+	FILE *f = fopen(filename, "wb");
 	if(!f) {
 		logger(mesh, MESHLINK_ERROR, "Error trying to create %s: %s\n", filename, strerror(errno));
 		return false;
@@ -210,7 +210,7 @@ static bool receive_invitation_sptps(void *handle, uint8_t type, const void *dat
 	}
 
 	// Open the renamed file
-	FILE *f = fopen(usedname, "r");
+	FILE *f = fopen(usedname, "rb");
 	if(!f) {
 		logger(mesh, MESHLINK_ERROR, "Error trying to open invitation %s\n", cookie);
 		return false;

--- a/src/sptps_keypair.c
+++ b/src/sptps_keypair.c
@@ -77,8 +77,8 @@ int main(int argc, char *argv[]) {
 	ecdsa_t *key = ecdsa_generate();
 	if(!key)
 		return 1;
-	
-	FILE *fp = fopen(argv[1], "w");
+
+	FILE *fp = fopen(argv[1], "wb");
 	if(fp) {
 		ecdsa_write_pem_private_key(key, fp);
 		fclose(fp);
@@ -87,7 +87,7 @@ int main(int argc, char *argv[]) {
 		return 1;
 	}
 
-	fp = fopen(argv[2], "w");
+	fp = fopen(argv[2], "wb");
 	if(fp) {
 		ecdsa_write_pem_public_key(key, fp);
 		fclose(fp);

--- a/src/sptps_test.c
+++ b/src/sptps_test.c
@@ -274,12 +274,12 @@ int main(int argc, char *argv[]) {
 
 	crypto_init();
 
-	FILE *fp = fopen(argv[1], "r");
+	FILE *fp = fopen(argv[1], "rb");
 	if(!(mykey = ecdsa_read_pem_private_key(fp)))
 		return 1;
 	fclose(fp);
 
-	fp = fopen(argv[2], "r");
+	fp = fopen(argv[2], "rb");
 	if(!(hiskey = ecdsa_read_pem_public_key(fp)))
 		return 1;
 	fclose(fp);


### PR DESCRIPTION
in meshlink_export ftell reports binary file size but fread replaces two
char line endings with one char causing uninitialized garbage at the end
of the text exported and transmitted
alternatively in textmode read each line one by one
