### PR TITLE
windows: fix unsupported %zu

### DIFF
--- a/examples/channels.c
+++ b/examples/channels.c
@@ -127,7 +127,7 @@ static void parse_command(meshlink_handle_t *mesh, char *buf) {
 			if(!nnodes) {
 				fprintf(stderr, "Could not get list of nodes: %s\n", meshlink_strerror(meshlink_errno));
 			} else {
-				printf("%zu known nodes:", nnodes);
+				printf("%lu known nodes:", (unsigned long)nnodes);
 				for(int i = 0; i < nnodes; i++)
 					printf(" %s", nodes[i]->name);
 				printf("\n");

--- a/examples/chat.c
+++ b/examples/chat.c
@@ -93,7 +93,7 @@ static void parse_command(meshlink_handle_t *mesh, char *buf) {
 			if(!nnodes) {
 				fprintf(stderr, "Could not get list of nodes: %s\n", meshlink_strerror(meshlink_errno));
 			} else {
-				printf("%zu known nodes:", nnodes);
+				printf("%lu known nodes:", (unsigned long)nnodes);
 				for(int i = 0; i < nnodes; i++)
 					printf(" %s", nodes[i]->name);
 				printf("\n");

--- a/examples/chatpp.cc
+++ b/examples/chatpp.cc
@@ -14,12 +14,12 @@ public:
 
 	void receive(meshlink::node *source, const void *data, size_t len) {
 		const char *msg = (const char *)data;
-	
+
 		if(!len || msg[len - 1]) {
 			fprintf(stderr, "Received invalid data from %s\n", source->name);
 			return;
 		}
-		
+
 		printf("%s says: %s\n", source->name, msg);
 	}
 
@@ -85,7 +85,7 @@ static void parse_command(meshlink::mesh *mesh, char *buf) {
 			if(!nodes) {
 				fprintf(stderr, "Could not get list of nodes: %s\n", meshlink::strerror());
 			} else {
-				printf("%zu known nodes:", nnodes);
+				printf("%lu known nodes:", (unsigned long)nnodes);
 				for(size_t i = 0; i < nnodes; i++)
 					printf(" %s", nodes[i]->name);
 				printf("\n");

--- a/examples/manynodes.c
+++ b/examples/manynodes.c
@@ -49,7 +49,7 @@ static void testmesh () {
 			if(!nodes) {
 				fprintf(stderr, "Could not get list of nodes: %s\n", meshlink_strerror(meshlink_errno));
 			} else {
-				printf("%zu known nodes:\n", nnodes);
+				printf("%lu known nodes:\n", (unsigned long)nnodes);
 				for(int i = 0; i < nnodes; i++) {
 					//printf(" %s\n", nodes[i]->name);
 						if(!meshlink_send(mesh[nindex], nodes[i], "magic", strlen("magic") + 1)) {
@@ -244,7 +244,7 @@ static void parse_command(char *buf) {
 			if(!nodes) {
 				fprintf(stderr, "Could not get list of nodes: %s\n", meshlink_strerror(meshlink_errno));
 			} else {
-				printf("%zu known nodes:", nnodes);
+				printf("%lu known nodes:", (unsigned long)nnodes);
 				for(int i = 0; i < nnodes; i++)
 					printf(" %s", nodes[i]->name);
 				printf("\n");
@@ -254,7 +254,7 @@ static void parse_command(char *buf) {
 			if(!node) {
 				fprintf(stderr, "Unknown node '%s'\n", arg);
 			} else {
-				printf("Node %s found, pmtu %zd\n", arg, meshlink_get_pmtu(mesh[nodeindex], node));
+				printf("Node %s found, pmtu %ld\n", arg, (long) meshlink_get_pmtu(mesh[nodeindex], node));
 			}
 		}
 	} else if(!strcasecmp(buf, "link")) {

--- a/examples/meshlinkapp.c
+++ b/examples/meshlinkapp.c
@@ -3,7 +3,7 @@
 #include "meshlink/meshlink.h"
 
 void handle_recv_data(meshlink_handle_t *mesh, meshlink_node_t *source, void *data, size_t len) {
-	printf("Received %zu bytes from %s: %s\n", len, source->name, (char*)data);
+	printf("Received %lu bytes from %s: %s\n", (unsigned long) len, source->name, (char*)data);
 }
 
 int main(int argc , char **argv){

--- a/test/channels-aio.c
+++ b/test/channels-aio.c
@@ -33,12 +33,12 @@ void status_cb(meshlink_handle_t *mesh, meshlink_node_t *node, bool reachable) {
 }
 
 void foo_aio_cb(meshlink_handle_t *mesh, meshlink_channel_t *channel, void *data, size_t len, void *priv) {
-	fprintf(stderr, "foo_aio_cb %p %zu %p\n", data, len, priv);
+	fprintf(stderr, "foo_aio_cb %p %lu %p\n", data, (unsigned long)len, priv);
 	foo_callbacks++;
 }
 
 void bar_aio_cb(meshlink_handle_t *mesh, meshlink_channel_t *channel, void *data, size_t len, void *priv) {
-	fprintf(stderr, "bar_aio_cb %p %zu %p\n", data, len, priv);
+	fprintf(stderr, "bar_aio_cb %p %lu %p\n", data, (unsigned long)len, priv);
 	bar_callbacks++;
 	if(!priv) { // Expecting a size_t equal to size
 		if(len != sizeof(size_t)) {
@@ -46,7 +46,7 @@ void bar_aio_cb(meshlink_handle_t *mesh, meshlink_channel_t *channel, void *data
 			exit(1);
 		}
 		if(*(size_t *)data != size) {
-			fprintf(stderr, "Unexpected data: %zu\n", *(size_t *)data);
+			fprintf(stderr, "Unexpected data: %lu\n", (unsigned long)(*(size_t *)data));
 			exit(1);
 		}
 
@@ -71,7 +71,7 @@ void bar_receive_cb(meshlink_handle_t *mesh, meshlink_channel_t *channel, const 
 		meshlink_channel_close(mesh, channel);
 		return ;
 	}
-	fprintf(stderr, "bar got %zu unexpected bytes via receive_cb\n", len);
+	fprintf(stderr, "bar got %lu unexpected bytes via receive_cb\n", (unsigned long)len);
 	exit(1);
 }
 
@@ -172,12 +172,12 @@ int main(int argc, char *argv[]) {
 	free(data);
 
 	// Set the callbacks.
-	
+
 	meshlink_set_channel_accept_cb(mesh1, reject_cb);
 	meshlink_set_channel_accept_cb(mesh2, accept_cb);
 
 	meshlink_set_node_status_cb(mesh1, status_cb);
-	
+
 	// Start both instances
 
 	if(!meshlink_start(mesh1)) {
@@ -204,7 +204,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	// Open a channel from foo to bar.
-	
+
 	meshlink_node_t *bar = meshlink_get_node(mesh1, "bar");
 	if(!bar) {
 		fprintf(stderr, "Foo could not find bar\n");
@@ -223,7 +223,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	meshlink_channel_t *channel = meshlink_channel_open(mesh1, bar, 7, NULL, NULL, 0);
-	
+
 	// Send a large buffer of data, preceded by the length of the data to be received.
 
 	// TODO: first bytes should be sendable using meshlink_channel_send(), however UTCP doesn't like storing data in its buffers before it has seen a SYNACK.
@@ -264,7 +264,7 @@ int main(int argc, char *argv[]) {
 		fprintf(stderr, "Received data does not match transmitted data\n");
 		for(size_t i = 0; i < size; i++) {
 			if(indata[i] != outdata[i]) {
-				fprintf(stderr, "Difference at position %zu: %x != %x\n", i, indata[i], outdata[i]);
+				fprintf(stderr, "Difference at position %lu: %x != %x\n", (unsigned long)i, indata[i], outdata[i]);
 				break;
 			}
 		}

--- a/test/channels.c
+++ b/test/channels.c
@@ -31,13 +31,13 @@ void status_cb(meshlink_handle_t *mesh, meshlink_node_t *node, bool reachable) {
 }
 
 void foo_receive_cb(meshlink_handle_t *mesh, meshlink_channel_t *channel, const void *data, size_t len) {
-	printf("foo_receive_cb %zu: ", len); fwrite(data, 1, len, stdout); printf("\n");
+	printf("foo_receive_cb %lu: ", (unsigned long)len); fwrite(data, 1, len, stdout); printf("\n");
 	if(len == 5 && !memcmp(data, "Hello", 5))
 		bar_responded = true;
 }
 
 void bar_receive_cb(meshlink_handle_t *mesh, meshlink_channel_t *channel, const void *data, size_t len) {
-	printf("bar_receive_cb %zu: ", len); fwrite(data, 1, len, stdout);
+	printf("bar_receive_cb %lu: ", (unsigned long)len); fwrite(data, 1, len, stdout);
 	// Echo the data back.
 	meshlink_channel_send(mesh, channel, data, len);
 }
@@ -115,12 +115,12 @@ int main(int argc, char *argv[]) {
 	free(data);
 
 	// Set the callbacks.
-	
+
 	meshlink_set_channel_accept_cb(mesh1, reject_cb);
 	meshlink_set_channel_accept_cb(mesh2, accept_cb);
 
 	meshlink_set_node_status_cb(mesh1, status_cb);
-	
+
 	// Start both instances
 
 	if(!meshlink_start(mesh1)) {
@@ -147,7 +147,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	// Open a channel from foo to bar.
-	
+
 	meshlink_node_t *bar = meshlink_get_node(mesh1, "bar");
 	if(!bar) {
 		fprintf(stderr, "Foo could not find bar\n");

--- a/test/sign-verify.c
+++ b/test/sign-verify.c
@@ -56,7 +56,7 @@ int main(int argc, char *argv[]) {
 		return 1;
 	}
 	if(siglen != MESHLINK_SIGLEN) {
-		fprintf(stderr, "Signature has unexpected length %zu != %zu\n", siglen, MESHLINK_SIGLEN);
+		fprintf(stderr, "Signature has unexpected length %lu != %lu\n", (unsigned long)siglen, (unsigned long)MESHLINK_SIGLEN);
 		return 1;
 	}
 


### PR DESCRIPTION
please never use %z, %zu or %zd, it is not supported by windows and
corrupts the stack
instead use %lu or %ld and convert to long integer
