### PR TITLE
Feature/fix win freeaddrinfo 1111

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -63,8 +63,9 @@ typedef struct outgoing_t {
 	int timeout;
 	struct splay_tree_t *config_tree;
 	struct config_t *cfg;
-	struct addrinfo *ai;
+	struct addrinfo *ai; // addresses from config files
 	struct addrinfo *aip;
+	struct addrinfo *nai; // addresses known via other online nodes (use free_known_addresses())
 	timeout_t ev;
 	struct meshlink_handle *mesh;
 } outgoing_t;

--- a/src/net_socket.c
+++ b/src/net_socket.c
@@ -478,35 +478,37 @@ begin:
 
 // Find edges pointing to this node, and use them to build a list of unique, known addresses.
 static struct addrinfo *get_known_addresses(node_t *n) {
-	struct addrinfo *ai = NULL;
+	return NULL;
 
-	for splay_each(edge_t, e, n->edge_tree) {
-		if(!e->reverse)
-			continue;
+	// struct addrinfo *ai = NULL;
 
-		bool found = false;
-		for(struct addrinfo *aip = ai; aip; aip = aip->ai_next) {
-			if(!sockaddrcmp(&e->reverse->address, (sockaddr_t *)aip->ai_addr)) {
-				found = true;
-				break;
-			}
-		}
-		if(found)
-			continue;
+	// for splay_each(edge_t, e, n->edge_tree) {
+	// 	if(!e->reverse)
+	// 		continue;
 
-		struct addrinfo *nai = xzalloc(sizeof *nai);
-		if(ai)
-			ai->ai_next = nai;
-		ai = nai;
-		ai->ai_family = e->reverse->address.sa.sa_family;
-		ai->ai_socktype = SOCK_STREAM;
-		ai->ai_protocol = IPPROTO_TCP;
-		ai->ai_addrlen = SALEN(e->reverse->address.sa);
-		ai->ai_addr = xmalloc(ai->ai_addrlen);
-		memcpy(ai->ai_addr, &e->reverse->address, ai->ai_addrlen);
-	}
+	// 	bool found = false;
+	// 	for(struct addrinfo *aip = ai; aip; aip = aip->ai_next) {
+	// 		if(!sockaddrcmp(&e->reverse->address, (sockaddr_t *)aip->ai_addr)) {
+	// 			found = true;
+	// 			break;
+	// 		}
+	// 	}
+	// 	if(found)
+	// 		continue;
 
-	return ai;
+	// 	struct addrinfo *nai = xzalloc(sizeof *nai);
+	// 	if(ai)
+	// 		ai->ai_next = nai;
+	// 	ai = nai;
+	// 	ai->ai_family = e->reverse->address.sa.sa_family;
+	// 	ai->ai_socktype = SOCK_STREAM;
+	// 	ai->ai_protocol = IPPROTO_TCP;
+	// 	ai->ai_addrlen = SALEN(e->reverse->address.sa);
+	// 	ai->ai_addr = xmalloc(ai->ai_addrlen);
+	// 	memcpy(ai->ai_addr, &e->reverse->address, ai->ai_addrlen);
+	// }
+
+	// return ai;
 }
 
 void setup_outgoing_connection(meshlink_handle_t *mesh, outgoing_t *outgoing) {


### PR DESCRIPTION
fixes cross-dll freeaddrinfo for windows that crashed for connecting multile nodes
