### PR TITLE
try_bind windows

### DIFF
--- a/examples/chatpp.cc
+++ b/examples/chatpp.cc
@@ -187,14 +187,14 @@ int main(int argc, char *argv[]) {
 		nick = argv[2];
 
 	ChatMesh mesh;
-	mesh.open(confbase, nick, "chatpp", DEV_CLASS_STATIONARY);
+	mesh.open(confbase, nick, "chatpp", DEV_CLASS_STATIONARY, MESHLINK_DEBUG);
 
 	if(!mesh.isOpen()) {
 		fprintf(stderr, "Could not open MeshLink: %s\n", meshlink::strerror());
 		return 1;
 	}
 
-	if(!mesh.start(MESHLINK_DEBUG)) {
+	if(!mesh.start()) {
 		fprintf(stderr, "Could not start MeshLink: %s\n", meshlink::strerror());
 		return 1;
 	}

--- a/include/meshlink/meshlink++.h
+++ b/include/meshlink/meshlink++.h
@@ -156,14 +156,17 @@ namespace meshlink {
 		 *  @param name     The name which this instance of the application will use in the mesh.
 		 *                  May be NULL if the configuration already exists.
 		 *  @param appname  The application name which will be used in the mesh.
-		 *  @param dclass   The device class which will be used in the mesh.
+		 *  @param devclass The device class which will be used in the mesh.
+		 *  @param loglevel Sets the meshlink log level. The applications logging callback can filter further as desired.
 		 *
 		 *  @return         This function will return a pointer to a meshlink::mesh if MeshLink has succesfully set up its configuration files, NULL otherwise.
 		 */ 
-		bool open(const char *confbase, const char *name, const char* appname, dev_class_t devclass) {
+		bool open(const char *confbase, const char *name, const char* appname, dev_class_t devclass, meshlink_log_level_t loglevel) {
 			handle = meshlink_open(confbase, name, appname, devclass);
-			if(handle)
+			if(handle) {
 				handle->priv = this;
+			        meshlink_set_log_cb(handle, loglevel, &log_trampoline);
+                        }
 			
 			return isOpen();
 		}
@@ -272,14 +275,11 @@ namespace meshlink {
 		/** This function causes MeshLink to open network sockets, make outgoing connections, and
 		 *  create a new thread, which will handle all network I/O.
 		 *
-		 *  @param loglevel Sets the meshlink log level. The applications logging callback can filter further as desired.
-		 *
 		 *  @return         This function will return true if MeshLink has succesfully started its thread, false otherwise.
 		 */
-		bool start(meshlink_log_level_t loglevel) {
+		bool start() {
 			meshlink_set_receive_cb       (handle, &receive_trampoline);
 			meshlink_set_node_status_cb   (handle, &node_status_trampoline);
-			meshlink_set_log_cb           (handle, loglevel, &log_trampoline);
 			meshlink_set_channel_accept_cb(handle, &channel_accept_trampoline);
 			return meshlink_start         (handle);
 		}

--- a/include/meshlink/meshlink++.h
+++ b/include/meshlink/meshlink++.h
@@ -171,8 +171,8 @@ namespace meshlink {
 			return isOpen();
 		}
 		
-		mesh(const char *confbase, const char *name, const char* appname, dev_class_t devclass) {
-			open(confbase, name, appname, devclass);
+		mesh(const char *confbase, const char *name, const char* appname, dev_class_t devclass, meshlink_log_level_t loglevel) {
+			open(confbase, name, appname, devclass, loglevel);
 		}
 		
 		/// Close the MeshLink handle.

--- a/src/meshlink.c
+++ b/src/meshlink.c
@@ -350,7 +350,6 @@ static bool try_bind(meshlink_handle_t *mesh, int port) {
 		.ai_socktype = SOCK_STREAM,
 		.ai_protocol = IPPROTO_TCP,
 	};
-	int option;
 
 	char portstr[16];
 	snprintf(portstr, sizeof portstr, "%d", port);
@@ -364,8 +363,6 @@ static bool try_bind(meshlink_handle_t *mesh, int port) {
 
 	while(ai) {
 		int fd = socket(ai->ai_family, SOCK_STREAM, IPPROTO_TCP);
-		option = 1;
-		setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (void *)&option, sizeof option);
 		if(!fd) {
 			logger(mesh, MESHLINK_DEBUG, "Failed to bind port: could not initialize socket.\n");
 			freeaddrinfo(ai_first);

--- a/src/meshlink.c
+++ b/src/meshlink.c
@@ -1073,8 +1073,13 @@ void meshlink_stop(meshlink_handle_t *mesh) {
 
 	// Send ourselves a UDP packet to kick the event loop
 	listen_socket_t *s = &mesh->listen_socket[0];
-	if(sendto(s->udp.fd, "", 1, MSG_NOSIGNAL, &s->sa.sa, SALEN(s->sa.sa)) == -1) {
-		logger(mesh, MESHLINK_ERROR, "Could not send a UDP packet to ourself. Error: ", sockstrerror(sockerrno));
+	sockaddr_t self;
+	memset(&self, 0, sizeof(sockaddr_t));
+	memcpy(&self, &s->sa, sizeof(sockaddr_t));
+	self.sa.sa_family = AF_INET;
+	self.in.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	if(sendto(s->udp.fd, "", 1, MSG_NOSIGNAL, &self.sa, SALEN(self.sa)) == -1) {
+		logger(mesh, MESHLINK_ERROR, "Could not send a UDP packet to ourself. Error: %s", sockstrerror(sockerrno));
 	}
 
 	// Wait for the main thread to finish

--- a/src/meshlink.c
+++ b/src/meshlink.c
@@ -1076,7 +1076,6 @@ void meshlink_stop(meshlink_handle_t *mesh) {
 	sockaddr_t self;
 	memset(&self, 0, sizeof(sockaddr_t));
 	memcpy(&self, &s->sa, sizeof(sockaddr_t));
-	logger(mesh, MESHLINK_DEBUG, "Setting address to loopback.");
 	if(s->sa.sa.sa_family == AF_INET) {
 		self.in.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 	} else if(s->sa.sa.sa_family == AF_INET6) {
@@ -1084,16 +1083,13 @@ void meshlink_stop(meshlink_handle_t *mesh) {
 	} else {
 		abort();
 	}
-	logger(mesh, MESHLINK_DEBUG, "Trying to send to loopback, port %d.", ntohs(self.in.sin_port));
 	// send at least 1 byte, otherwise receive function throws error
 	if(sendto(s->udp.fd, "\0", 1, MSG_NOSIGNAL, &self.sa, SALEN(self.sa)) == -1) {
 		logger(mesh, MESHLINK_ERROR, "Could not send a UDP packet to ourself. Error: %s", sockstrerror(sockerrno));
 	}
 
-	logger(mesh, MESHLINK_DEBUG, "Sent kick to self.");
 	// Wait for the main thread to finish
 	MESHLINK_MUTEX_UNLOCK(&(mesh->mesh_mutex));
-	logger(mesh, MESHLINK_DEBUG, "Waiting for thread to finish.");
 	pthread_join(mesh->thread, NULL);
 	MESHLINK_MUTEX_LOCK(&(mesh->mesh_mutex));
 

--- a/src/meshlink.c
+++ b/src/meshlink.c
@@ -355,7 +355,7 @@ static bool try_bind(meshlink_handle_t *mesh, int port) {
 	snprintf(portstr, sizeof portstr, "%d", port);
 
 	if(getaddrinfo(NULL, portstr, &hint, &ai) || !ai) {
-		logger(mesh, MESHLINK_DEBUG, "Failed to bind port: could got parse address info.\n");
+		logger(mesh, MESHLINK_DEBUG, "Failed to bind port: could not parse address info.\n");
 		return false;
 	}
 

--- a/src/meshlink.c
+++ b/src/meshlink.c
@@ -367,17 +367,17 @@ static bool try_bind(meshlink_handle_t *mesh, int port) {
 		option = 1;
 		setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (void *)&option, sizeof option);
 		if(!fd) {
-			freeaddrinfo(ai_first);
 			logger(mesh, MESHLINK_DEBUG, "Failed to bind port: could not initialize socket.\n");
-			return false;
-		}
-		int result = bind(fd, ai->ai_addr, ai->ai_addrlen);
-		closesocket(fd);
-		if(result) {
 			freeaddrinfo(ai_first);
-			logger(mesh, MESHLINK_DEBUG, "Failed to bind port: failed to bind socket, %s\n", sockstrerror(sockerrno));
 			return false;
 		}
+		if(bind(fd, ai->ai_addr, ai->ai_addrlen)) {
+			logger(mesh, MESHLINK_DEBUG, "Failed to bind port: failed to bind socket, %s\n", sockstrerror(sockerrno));
+			closesocket(fd);
+			freeaddrinfo(ai_first);
+			return false;
+		}
+		closesocket(fd);
 		ai = ai->ai_next;
 	}
 

--- a/src/meshlink.c
+++ b/src/meshlink.c
@@ -372,7 +372,7 @@ static bool try_bind(meshlink_handle_t *mesh, int port) {
 		closesocket(fd);
 		if(result) {
 			freeaddrinfo(ai_first);
-			logger(mesh, MESHLINK_DEBUG, "Failed to bind port: failed to bind socket, return code %d\n", result);
+			logger(mesh, MESHLINK_DEBUG, "Failed to bind port: failed to bind socket, %s\n", strerror(errno));
 			return false;
 		}
 		ai = ai->ai_next;

--- a/src/meshlink.c
+++ b/src/meshlink.c
@@ -1073,8 +1073,9 @@ void meshlink_stop(meshlink_handle_t *mesh) {
 
 	// Send ourselves a UDP packet to kick the event loop
 	listen_socket_t *s = &mesh->listen_socket[0];
-	if(sendto(s->udp.fd, "", 1, MSG_NOSIGNAL, &s->sa.sa, SALEN(s->sa.sa)) == -1)
-		logger(mesh, MESHLINK_ERROR, "Could not send a UDP packet to ourself");
+	if(sendto(s->udp.fd, "", 1, MSG_NOSIGNAL, &s->sa.sa, SALEN(s->sa.sa)) == -1) {
+		logger(mesh, MESHLINK_ERROR, "Could not send a UDP packet to ourself. Error: ", sockstrerror(sockerrno));
+	}
 
 	// Wait for the main thread to finish
 	MESHLINK_MUTEX_UNLOCK(&(mesh->mesh_mutex));

--- a/src/meshlink.c
+++ b/src/meshlink.c
@@ -350,6 +350,7 @@ static bool try_bind(meshlink_handle_t *mesh, int port) {
 		.ai_socktype = SOCK_STREAM,
 		.ai_protocol = IPPROTO_TCP,
 	};
+	int option;
 
 	char portstr[16];
 	snprintf(portstr, sizeof portstr, "%d", port);
@@ -363,6 +364,8 @@ static bool try_bind(meshlink_handle_t *mesh, int port) {
 
 	while(ai) {
 		int fd = socket(ai->ai_family, SOCK_STREAM, IPPROTO_TCP);
+		option = 1;
+		setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (void *)&option, sizeof option);
 		if(!fd) {
 			freeaddrinfo(ai_first);
 			logger(mesh, MESHLINK_DEBUG, "Failed to bind port: could not initialize socket.\n");

--- a/src/meshlink.c
+++ b/src/meshlink.c
@@ -372,7 +372,7 @@ static bool try_bind(meshlink_handle_t *mesh, int port) {
 		closesocket(fd);
 		if(result) {
 			freeaddrinfo(ai_first);
-			logger(mesh, MESHLINK_DEBUG, "Failed to bind port: failed to bind socket, %s\n", strerror(errno));
+			logger(mesh, MESHLINK_DEBUG, "Failed to bind port: failed to bind socket, %s\n", sockstrerror(sockerrno));
 			return false;
 		}
 		ai = ai->ai_next;

--- a/src/net_packet.c
+++ b/src/net_packet.c
@@ -605,6 +605,7 @@ void handle_incoming_vpn_data(event_loop_t *loop, void *data, int flags) {
 	}
 
 	pkt.len = len;
+	logger(mesh, MESHLINK_DEBUG, "Received %d bytes of vpn data.", pkt.len);
 
 	sockaddrunmap(&from); /* Some braindead IPv6 implementations do stupid things. */
 


### PR DESCRIPTION
 See everbase/backend#1373.

This pull request:
- modifies the API to set the log level at `open` rather than `start`, so that functions called before `start` (like `open`, `set_port`, etc.) have logging as well.
- adds error logging
- changes `meshlink_stop` to explicitly send to `INADDR_LOOPBACK` rather than `INADDR_ANY`. These appear to be handled equivalently on linux but on windows sending to `INADDR_ANY` is an error.
