### PR TITLE
Add functions to get the amount of bytes in channel send and receive buffers.

### DIFF
--- a/src/meshlink++.h
+++ b/src/meshlink++.h
@@ -691,6 +691,30 @@ public:
 		return meshlink_channel_send(handle, channel, data, len);
 	}
 
+	/// Get the amount of bytes in the send buffer.
+	/** This returns the amount of bytes in the send buffer.
+	 *  These bytes have not been received by the peer yet.
+	 *
+	 *  @param channel      A handle for the channel.
+	 *
+	 *  @return             The amount of un-ACKed bytes in the send buffer.
+	 */
+	size_t channel_get_sendq(channel *channel) {
+		return meshlink_channel_get_sendq(handle, channel);
+	}
+
+	/// Get the amount of bytes in the receive buffer.
+	/** This returns the amount of bytes in the receive buffer.
+	 *  These bytes have not been processed by the application yet.
+	 *
+	 *  @param channel      A handle for the channel.
+	 *
+	 *  @return             The amount of bytes in the receive buffer.
+	 */
+	size_t channel_get_recvq(channel *channel) {
+		return meshlink_channel_get_recvq(handle, channel);
+	}
+
 	/// Enable or disable zeroconf discovery of local peers
 	/** This controls whether zeroconf discovery using the Catta library will be
 	 *  enabled to search for peers on the local network. By default, it is enabled.

--- a/src/meshlink.c
+++ b/src/meshlink.c
@@ -3159,6 +3159,24 @@ uint32_t meshlink_channel_get_flags(meshlink_handle_t *mesh, meshlink_channel_t 
 	return channel->c->flags;
 }
 
+size_t meshlink_channel_get_sendq(meshlink_handle_t *mesh, meshlink_channel_t *channel) {
+	if(!mesh || !channel) {
+		meshlink_errno = MESHLINK_EINVAL;
+		return -1;
+	}
+
+	return utcp_get_sendq(channel->c);
+}
+
+size_t meshlink_channel_get_recvq(meshlink_handle_t *mesh, meshlink_channel_t *channel) {
+	if(!mesh || !channel) {
+		meshlink_errno = MESHLINK_EINVAL;
+		return -1;
+	}
+
+	return utcp_get_recvq(channel->c);
+}
+
 void update_node_status(meshlink_handle_t *mesh, node_t *n) {
 	if(n->status.reachable && mesh->channel_accept_cb && !n->utcp) {
 		n->utcp = utcp_init(channel_accept, channel_pre_accept, channel_send, n);

--- a/src/meshlink.h
+++ b/src/meshlink.h
@@ -1021,6 +1021,28 @@ extern ssize_t meshlink_channel_send(meshlink_handle_t *mesh, meshlink_channel_t
  */
 extern uint32_t meshlink_channel_get_flags(meshlink_handle_t *mesh, meshlink_channel_t *channel);
 
+/// Get the amount of bytes in the send buffer.
+/** This returns the amount of bytes in the send buffer.
+ *  These bytes have not been received by the peer yet.
+ *
+ *  @param mesh         A handle which represents an instance of MeshLink.
+ *  @param channel      A handle for the channel.
+ *
+ *  @return             The amount of un-ACKed bytes in the send buffer.
+ */
+extern size_t meshlink_channel_get_sendq(meshlink_handle_t *mesh, meshlink_channel_t *channel);
+
+/// Get the amount of bytes in the receive buffer.
+/** This returns the amount of bytes in the receive buffer.
+ *  These bytes have not been processed by the application yet.
+ *
+ *  @param mesh         A handle which represents an instance of MeshLink.
+ *  @param channel      A handle for the channel.
+ *
+ *  @return             The amount of bytes in the receive buffer.
+ */
+extern size_t meshlink_channel_get_recvq(meshlink_handle_t *mesh, meshlink_channel_t *channel);
+
 /// Hint that a hostname may be found at an address
 /** This function indicates to meshlink that the given hostname is likely found
  *  at the given IP address and port.


### PR DESCRIPTION
meshlink_channel_get_sendq() and meshlink_channel_get_recvq() call the
underlying UTCP connection's utcp_get_sendq() and utcp_get_recvq().
These return the amount of bytes waiting in the send and receive buffers.
In particular, a non-zero value for sendq means that sent data has not been
ACKed by the peer yet.